### PR TITLE
Adding the DNSSEC Parental Agent actor

### DIFF
--- a/DNS3-RR-Protocol.md
+++ b/DNS3-RR-Protocol.md
@@ -138,7 +138,8 @@ interpreted as described in [@RFC2119].
 
 # Process Overview
 
-## Identifying the Registrar
+## Identifying the Registrar (or registry or reseller) The DNSSEC Parental Agent
+(JACQUES: testing in github direct change)
 
 As of publication of this document, there has never been a standardized or
 widely deployed method for easily and scalably identifying the Registar for a


### PR DESCRIPTION
(**TESTING** DIRECT GITHUB FILE EDIT, my first Jacques)
Hi,

After today’s session it occurred to me that;
  1) the draft excludes the registry or resellers from doing CDS operations, 
2) we don’t have a name for the role of the actor that performs the CDS operations.  We should call it the DNSSEC Parental Agent?
3) the DNSSEC Parental Agent can be either the Registrar or Registry or Reseller, depending on where RDAP points.

## Identifying the Registrar (or Registry or Reseller)
TO
## Identifying the DNSSEC Parental Agent

Right? And all associated text.

Jack